### PR TITLE
Fixes #30911 - Fix issue with selecting host ids for Upgrade Button

### DIFF
--- a/lib/foreman_leapp/version.rb
+++ b/lib/foreman_leapp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanLeapp
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/webpack/components/PreupgradeReports/PreupgradeReports.js
+++ b/webpack/components/PreupgradeReports/PreupgradeReports.js
@@ -110,8 +110,8 @@ const PreupgradeReports = ({
   );
 };
 
-const withLoadingState = Component => props => {
-  const { error, loading, preupgradeReports, reportsExpected } = props;
+const withLoadingState = Component => componentProps => {
+  const { error, loading, preupgradeReports, reportsExpected } = componentProps;
 
   if (!isEmpty(error)) {
     return (
@@ -126,7 +126,7 @@ const withLoadingState = Component => props => {
   return (
     <LoadingState loading={loading}>
       {preupgradeReports.length > 0 ? (
-        <Component {...props} />
+        <Component {...componentProps} />
       ) : (
         <NoReports reportsExpected={reportsExpected} />
       )}

--- a/webpack/components/PreupgradeReports/components/UpgradeAllButton.js
+++ b/webpack/components/PreupgradeReports/components/UpgradeAllButton.js
@@ -3,22 +3,21 @@ import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-import { idsForInvocationFromReports } from '../PreupgradeReportsHelpers';
-
-const UpgradeAllButton = ({ preupgradeReports, postUrl, csrfToken }) => {
-  const { hostIds } = idsForInvocationFromReports(preupgradeReports);
-
-  return (
-    <form action={postUrl} method="post">
-      <Button type="submit">{__('Run Upgrade')}</Button>
-      <input type="hidden" name="authenticity_token" value={csrfToken} />
-      <input type="hidden" name="feature" value="leapp_upgrade" />
-      {hostIds.map(hostId => (
-        <input type="hidden" name="host_ids[]" key={hostId} value={hostId} />
-      ))}
-    </form>
-  );
-};
+const UpgradeAllButton = ({ preupgradeReports, postUrl, csrfToken }) => (
+  <form action={postUrl} method="post">
+    <Button type="submit">{__('Run Upgrade')}</Button>
+    <input type="hidden" name="authenticity_token" value={csrfToken} />
+    <input type="hidden" name="feature" value="leapp_upgrade" />
+    {preupgradeReports.map(report => (
+      <input
+        type="hidden"
+        name="host_ids[]"
+        key={report.hostId}
+        value={report.hostId}
+      />
+    ))}
+  </form>
+);
 
 UpgradeAllButton.propTypes = {
   preupgradeReports: PropTypes.array.isRequired,

--- a/webpack/components/PreupgradeReports/components/__snapshots__/UpgradeAllButton.test.js.snap
+++ b/webpack/components/PreupgradeReports/components/__snapshots__/UpgradeAllButton.test.js.snap
@@ -25,5 +25,17 @@ exports[`UpgradeAllButton should render 1`] = `
     type="hidden"
     value="leapp_upgrade"
   />
+  <input
+    key="5"
+    name="host_ids[]"
+    type="hidden"
+    value={5}
+  />
+  <input
+    key="6"
+    name="host_ids[]"
+    type="hidden"
+    value={6}
+  />
 </form>
 `;


### PR DESCRIPTION
**How to reproduce issue**
* Preupgrade job without any items that can be fixed by Leapp tool (without commands)
* At _Leapp preupgrade report_ tab, click on _Run Upgrade_ button

After redirect _Search Query_ on Job invocation form is empty.

**Fix**
Not using `idsForInvocationFromReports`.