### PR TITLE
Fixes #36863 - Preupgrade report authorization issue for non-admin users

### DIFF
--- a/app/models/preupgrade_report.rb
+++ b/app/models/preupgrade_report.rb
@@ -7,12 +7,17 @@ class PreupgradeReport < ::Report
   scoped_search on: :job_invocation_id, only_explicit: true
 
   def self.create_report(host, data, job_invocation_id)
-    report = PreupgradeReport.create(host: host, status: 0,
-                                     job_invocation_id: job_invocation_id,
-                                     reported_at: DateTime.now.utc)
+    # We don't have specific permissions for the Preupgrade leapp reports,
+    # so we need to skip the permission check for non-admin users.
+    # The user is still required to have permission to run the job and view the hosts.
+    skip_permission_check do
+      report = PreupgradeReport.create  host: host, status: 0,
+                                        job_invocation_id: job_invocation_id,
+                                        reported_at: DateTime.now.utc
 
-    data['entries']&.each do |entry|
-      PreupgradeReportEntry.create! entry_params(report, entry, host, data)
+      data['entries']&.each do |entry|
+        PreupgradeReportEntry.create! entry_params(report, entry, host, data)
+      end
     end
   end
 

--- a/lib/foreman_leapp/version.rb
+++ b/lib/foreman_leapp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanLeapp
-  VERSION = '0.1.14'
+  VERSION = '0.1.15'
 end


### PR DESCRIPTION
We don't have specific permissions for the Preupgrade leapp reports, so we need to skip the permission check for non-admin users. The user is still required to have permission to run the job and view the hosts.

(cherry picked from commit a41ca48a671fef5c10eccc902f7c3e449122a8e2)