### PR TITLE
Make the channel input optional in the pre-upgrade template.

### DIFF
--- a/app/views/foreman_leapp/job_templates/leapp_preupgrade.erb
+++ b/app/views/foreman_leapp/job_templates/leapp_preupgrade.erb
@@ -10,12 +10,12 @@ template_inputs:
 - name: Channel
   description: "Set if the target OS is required to use the General Availability (GA) channel - the default - or a specific channel among: Update Services for SAP Solutions (E4S), Extended Upgrade Support (EUS) or Advanced Update Support (AUS)."
   input_type: user
-  required: true
+  required: false
   default: "ga"
   options: "ga\ne4s\neus\naus"
 %>
 <%
-  channel_opts = input('Channel') == 'ga' ? '' : "--channel #{input('Channel')}"
+  channel_opts = "--channel #{input('Channel') || 'ga'}"
 %>
 
 <%= render_template 'Check Leapp' %>


### PR DESCRIPTION
With the optional input, other templates can render the pre-upgrade template without specifying the value.

For steps to reproduce, see https://issues.redhat.com/browse/SAT-28216