### PR TITLE
fix 38099 - Set channel parameter to ansible variable

### DIFF
--- a/app/views/foreman_leapp/job_templates/leapp_upgrade.erb
+++ b/app/views/foreman_leapp/job_templates/leapp_upgrade.erb
@@ -23,7 +23,7 @@ template_inputs:
 ---
 - hosts: all
   vars:
-    - channel_opts: <% input('Channel') == 'ga' ? '' : "--channel #{input('Channel')}" %>
+    - channel_opts: <%= input('Channel') == 'ga' ? '' : "--channel #{input('Channel')}" %>
   tasks:
     - name: Run Leapp Upgrade
       command: leapp upgrade {{ channel_opts }}


### PR DESCRIPTION
This commit fix the typo where the channel parameter wasn't pass to ansible variable

ref. https://projects.theforeman.org/issues/38099