### PR TITLE
Fixes #38525 - check job_features before DB lookup in correct_feature?

### DIFF
--- a/app/lib/helpers/job_helper.rb
+++ b/app/lib/helpers/job_helper.rb
@@ -3,10 +3,16 @@
 module Helpers
   module JobHelper
     class << self
+      # Returns true if the given feature is present in the job_invocation's job_features,
+      # or if a matching RemoteExecutionFeature exists for the job_template.
       def correct_feature?(job_invocation, feature)
-        RemoteExecutionFeature.where(job_template_id: job_invocation.pattern_template_invocations
-                                                                    .first
-                                                                    .template_id, label: feature).any?
+        # check if the feature exists in the DB for the job_template
+        template_id = job_invocation.pattern_template_invocations.first.template_id
+        return true if RemoteExecutionFeature.exists?(job_template_id: template_id, label: feature)
+
+        # Fallback: check if the feature is present in job_features
+        job_features = Array(job_invocation.task&.input&.[]('job_features'))
+        job_features.include?(feature)
       end
     end
   end

--- a/test/unit/helpers/job_helper_test.rb
+++ b/test/unit/helpers/job_helper_test.rb
@@ -8,22 +8,63 @@ module Helpers
 
     let(:job_template) do
       FactoryBot.create(:job_template, template: 'echo "1"', job_category: 'leapp',
-        provider_type: 'SSH', name: 'Leapp preupgrade')
+                        provider_type: 'SSH', name: 'Leapp preupgrade')
     end
-    let(:job_invocation) { FactoryBot.create(:job_invocation) }
+    let(:job_invocation) { FactoryBot.create(:job_invocation, :with_task) }
+    let(:feature_label) { 'leapp_preupgrade' }
+
+    setup do
+      FactoryBot.create(:template_invocation, template: job_template, job_invocation: job_invocation)
+    end
 
     describe 'correct_feature?' do
-      setup do
-        RemoteExecutionFeature.find_by(label: 'leapp_preupgrade').update(job_template: job_template)
-        FactoryBot.create(:template_invocation, template: job_template, job_invocation: job_invocation)
+      test 'returns true when feature is listed in job_features' do
+        job_invocation.task.stubs(:input).returns({ 'job_features' => [feature_label] })
+        assert helper.correct_feature?(job_invocation, feature_label)
       end
 
-      it 'correct feature' do
-        assert helper.correct_feature?(job_invocation, 'leapp_preupgrade')
+      test 'returns false when job_features does not include the feature and DB has no match' do
+        job_invocation.task.stubs(:input).returns({ 'job_features' => ['some_other_feature'] })
+        assert_not helper.correct_feature?(job_invocation, feature_label)
       end
 
-      it 'wrong feature' do
-        assert_not helper.correct_feature?(job_invocation, 'leapp_preupgrade2')
+      test 'returns true when job_features does not include the feature but DB does match' do
+        RemoteExecutionFeature.find_by(label: feature_label).update(job_template: job_template)
+        job_invocation.task.stubs(:input).returns({ 'job_features' => ['some_other_feature'] })
+        assert helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns true when job_features key is missing but DB matches' do
+        RemoteExecutionFeature.find_by(label: feature_label).update(job_template: job_template)
+        job_invocation.task.stubs(:input).returns({})
+        assert helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns false when job_features key is missing and DB does not match' do
+        job_invocation.task.stubs(:input).returns({})
+        assert_not helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns false when job_features is nil and DB does not match' do
+        job_invocation.task.stubs(:input).returns({ 'job_features' => nil })
+        assert_not helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns true when job_features is nil but DB matches' do
+        RemoteExecutionFeature.find_by(label: feature_label).update(job_template: job_template)
+        job_invocation.task.stubs(:input).returns({ 'job_features' => nil })
+        assert helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns false when task is nil and feature not found in DB' do
+        job_invocation.stubs(:task).returns(nil)
+        assert_not helper.correct_feature?(job_invocation, feature_label)
+      end
+
+      test 'returns true when task is nil but DB matches' do
+        RemoteExecutionFeature.find_by(label: feature_label).update(job_template: job_template)
+        job_invocation.stubs(:task).returns(nil)
+        assert helper.correct_feature?(job_invocation, feature_label)
       end
     end
   end


### PR DESCRIPTION
This should fix the bug where the "Leapp preupgrade report" tab on the job invocations UI page disappears.

Reproducer steps:
1. Clone the default "Run preupgrade via Leapp" job template:
Hosts --> Templates --> Job Templates --> "Run preupgrade via Leapp" --> Clone
Make desired modifications to the cloned template and name it "Run preupgrade via Leapp clone"

2. Run leapp preupgrade on a host using the default template:
Hosts --> All Hosts --> select host --> Select Action --> Preupgrade check with Leapp --> Run on selected hosts
Open the job details in WebUI (https://&lt;satellite&gt;/job_invocations/&lt;id&gt;) and you will see "Leapp Preupgrade Report" tab as expected

3. Choose the cloned template in REX features:
Administer --> Remote Execution Features --> leapp_preupgrade --> "Run preupgrade via Leapp clone"

4. Run leapp preupgrade on the same host using the cloned template:
Hosts --> All Hosts --> select host --> Select Action --> Preupgrade check with Leapp --> Run on selected hosts
Open the job details in WebUI (https://&lt;satellite&gt;/job_invocations/&lt;id&gt;) and you will see "Leapp Preupgrade Report" tab as expected

5. Open the job invocation details belonging to the first job and you will see that "Leapp Preupgrade Report" tab disappeared. Presumably as a consequence of the second job.

Additional details:
This happens only when the job template changes.